### PR TITLE
Mark as deprecated in the meta using [Deprecated].

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,3 +4,4 @@ license = Perl_5
 copyright_holder = Alan Young
 
 [@Author::BLUEFEET]
+[Deprecated]


### PR DESCRIPTION
Hi @bluefeet 

Please review the PR.
Marked the distribution as "Deprecated" using the tips suggested by Neil Bowers blog below:

http://neilb.org/2015/01/17/deprecated-metadata.html

Many Thanks.
Best Regards,
Mohammad S Anwar